### PR TITLE
fix: tutorial links

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -22,8 +22,8 @@ function find(spec) {
   return helper.find(data, spec);
 }
 
-function tutoriallink(tutorial) {
-  return helper.toTutorial(tutorial, null, {
+function tutoriallink(longName, name) {
+  return helper.toTutorial(longName, null, {
     tag: 'em',
     classname: 'disabled',
     prefix: 'Tutorial: '
@@ -340,7 +340,7 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
 }
 
 function linktoTutorial(longName, name) {
-  return tutoriallink(name);
+  return tutoriallink(longName, name);
 }
 
 function linktoExternal(longName, name) {


### PR DESCRIPTION
We were using the link "content" to lookup the tutorial, due to some changes this text was prefixed with a space so it failed to lookup the right tutorial. This wasn't noticed since we don't use any tutorials currently but should be fixed so we can use them at some point.