### PR TITLE
fix: move tutorials to the top of the nav

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -377,6 +377,9 @@ function buildNav(members, opts) {
            </div>`;
   nav += `<div data-navigation-scroll class="navigation__scroll scroll trim">`;
   nav += `<div data-navigation class="navigation__menu trim">`;
+
+  nav += buildMemberNav(members.tutorials, '', seenTutorials, linktoTutorial);
+
   nav += buildMemberNav(members.modules, 'Modules', {}, linkto);
   // externals are turned off hardcoded, because we don't use them. Also the Homey ZigbeeDriver can't be configured to turn them off.
   // nav += buildMemberNav(members.externals, 'Externals', seen, linktoExternal);
@@ -395,7 +398,6 @@ function buildNav(members, opts) {
   nav += buildMemberNav(members.interfaces, 'Interfaces', seen, linkto);
   // nav += buildMemberNav(members.events, 'Events', seen, linkto);
   nav += buildMemberNav(members.mixins, 'Mixins', seen, linkto);
-  nav += buildMemberNav(members.tutorials, opts.tutorialsNavHeading || 'Tutorials', seenTutorials, linktoTutorial);
 
   if (members.globals.length) {
     globalNav = '';


### PR DESCRIPTION
This moves the tutorials to the top of the sidebar navigation.
I sort of want to add a "Home" link to the tutorials section but I'm not sure what the best way to do that would be and in the meantime this seems like an improvement.