### PR TITLE
fix: align repository.url with actual repo name

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/athombv/homey-jsdoc-template.git"
+    "url": "git+https://github.com/athombv/jsdoc-template.git"
   },
   "browserslist": [
     "last 5 Chrome versions",


### PR DESCRIPTION
The repository was renamed from `homey-jsdoc-template` to `jsdoc-template`, but `package.json`'s `repository.url` still pointed at the old URL. The first 1.7.0 publish failed because npm verifies that `repository.url` matches the source repo from the OIDC token, and `homey-jsdoc-template` does not match `jsdoc-template`:

> 422 Unprocessable Entity - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/athombv/homey-jsdoc-template.git", expected to match "https://github.com/athombv/jsdoc-template" from provenance

After merging this, re-merge `master` into `production` to retry the 1.7.0 publish. The 1.7.0 version is still available on npmjs.org because the previous publish was rejected before any version metadata was persisted.